### PR TITLE
fix(basic): incorrect name of userInfo

### DIFF
--- a/connector-basic/basic.go
+++ b/connector-basic/basic.go
@@ -149,7 +149,7 @@ func (g *Connector) ConnectorReceiver(ctx *plugin.GinContext, receiverURL string
 	userInfo = plugin.ExternalLoginUserInfo{
 		MetaInfo: string(data),
 	}
-	log.Errorf("[jw log] userInfo :  %s", uerInfo)
+	log.Errorf("[jw log] userInfo :  %v", userInfo)
 	
 	if len(g.Config.UserIDJsonPath) > 0 {
 		userInfo.ExternalID = gjson.GetBytes(data, g.Config.UserIDJsonPath).String()


### PR DESCRIPTION
```go
userInfo = plugin.ExternalLoginUserInfo{
		MetaInfo: string(data),
	}
```

It is the `userInfo` not `uerInfo`.